### PR TITLE
Update popup logo with improved styling

### DIFF
--- a/popup/popup.html
+++ b/popup/popup.html
@@ -9,7 +9,7 @@
 <body>
   <div class="container">
     <div class="header">
-      <img src="../assets/logo.svg" alt="CvToLetter Logo" class="logo">
+      <img src="../assets/logo.svg" alt="CvToLetter Logo" class="logo" style="width: 48px; height: 48px;">
       <h1>CvToLetter</h1>
     </div>
 


### PR DESCRIPTION
## Logo Update

- Added improved logo styling in the popup
- Set logo size to 48x48 pixels
- Maintains brand consistency with the existing SVG logo

### Changes
- Updated `popup/popup.html`
- Added inline style to logo image to set consistent size
- No functional changes to the extension

### Test Instructions
1. Open the Chrome extension popup
2. Verify the logo is crisp and properly sized
3. Confirm all other functionality remains the same